### PR TITLE
faq: check server: new URL

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -159,7 +159,7 @@ defined:
 The easiest way is to check with a special test server that will confirm MPTCP
 is being used and return that info to the client, e.g.
 ```bash
-$ mptcpize run curl http://test.multipath-tcp.org:5000
+$ mptcpize run curl https://check.mptcp.dev
 You are using MPTCP.
 ```
 


### PR DESCRIPTION
Instead of using multipath-tcp.org which might be confusing with the fork, and on port 5000, not HTTPS: now using https://check.mptcp.dev

Some more info will be added on this page: link, the curl cmd with mptcpize, test files to download