### PR TITLE
contributing: add missing refs

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -9,12 +9,12 @@ titles_max_depth: 2
 ## Many ways to contributes
 
 There are many ways to contribute to MPTCP in general:
-- Reporting bugs
-- Testing the development version
+- [Reporting bugs](https://github.com/multipath-tcp/mptcp_net-next/issues)
+- [Testing the development version](https://github.com/multipath-tcp/mptcp-upstream-virtme-docker)
 - Talking about it on social media, mailing lists, conferences, etc.
 - Sending supportive messages to other contributors
-- Helping new users on different platforms: mailing lists, IRC, external
-  services
+- Helping new users on different platforms: [mailing lists, IRC, external
+  services](/#communication)
 - Asking to enable it by default on services (servers) and devices
 - Adding [native MPTCP support in apps](apps.html) (or asking app developers to
   add native MPTCP support)

--- a/contributing.md
+++ b/contributing.md
@@ -6,7 +6,7 @@ nav_titles: true
 titles_max_depth: 2
 ---
 
-## Many ways to contributes
+## Many ways to contribute
 
 There are many ways to contribute to MPTCP in general:
 - [Reporting bugs](https://github.com/multipath-tcp/mptcp_net-next/issues)


### PR DESCRIPTION
It is good to say that there are ways to contribute, but no references were used to help readers to know where to go to contribute in one way or another, even if they are mentioned somewhere on the website.

Reported-by: Igu and Maja from APC.org.