### PR TITLE
apps: add OpenWRT support

### DIFF
--- a/apps.md
+++ b/apps.md
@@ -58,6 +58,7 @@ mentioned. Please note that other apps can be forced to use it by following
 | Name | Version |
 | --- | --- |
 | [Open MPTCP Router](https://www.openmptcprouter.com) | v0.60 |
+| [OpenWRT](https://openwrt.org) | [v24](https://github.com/openwrt/openwrt/pull/16786) |
 
 ## Add native MPTCP support
 


### PR DESCRIPTION
OpenWRT's future version (v24?) will support MPTCP by default on non "small flash" targets. No need for custom builds or forks!

Thanks to @dangowrt, @rodsmar, and @sKyissKy for the work, and @hauke for the review!

Link: https://github.com/openwrt/openwrt/pull/16786