### PR TITLE
os: add Amazon & Azure Linux

### DIFF
--- a/apps.md
+++ b/apps.md
@@ -40,6 +40,8 @@ package available in the official repositories:
 | --- | --- | :---: | --- |
 | [ArchLinux](https://archlinux.org) | ✅ | ❌ | Rolling release: MPTCP support is enabled since kernel v5.6. |
 | [Alpine Linux](https://alpinelinux.org) | 3.20 | ❌ | MPTCP was available before in 'linux-edge'. |
+| [Amazon Linux](https://aws.amazon.com/linux/amazon-linux-2023/) | 2023 | ❌ | |
+| [Azure Linux](https://github.com/microsoft/AzureLinux) | [3.0](https://github.com/microsoft/azurelinux/pull/10014) | ❌ | |
 | [Debian](https://www.debian.org) | 12 | ✅ | |
 | [Fedora](https://fedoraproject.org) | 36 | ✅ | |
 | [Gentoo](https://www.gentoo.org) | ✅ | ✅ | Version: to be completed. |


### PR DESCRIPTION
I don't think mptcpd is packaged: these OS are mainly to execute containers.

For Amazon, it looks like MPTCP is available according to this issue containing a full dmesg log where we can see MPTCP token hash table has been initialised:

  https://github.com/amazonlinux/amazon-linux-2023/issues/696