### PR TITLE
sysctl: use '-w' to change setting

### DIFF
--- a/pm.md
+++ b/pm.md
@@ -167,7 +167,7 @@ long as the `subflows` [limit](#limits) has not been reached yet.
 
 ## Userspace Path-Manager
 
-With the userspace MPTCP path-manager -- `sysctl net.mptcp.pm_type=1` --
+With the userspace MPTCP path-manager -- `sysctl -w net.mptcp.pm_type=1` --
 different rules can be applied for each connection. The path-manager will then
 need to be controlled by a userspace daemon, i.e.
 [`mptcpd`](https://mptcpd.mptcp.dev). In this case, the configuration has to be

--- a/setup.md
+++ b/setup.md
@@ -49,7 +49,7 @@ If available, MPTCP should be enabled by default. If not, change this `sysctl`
 knob:
 
 ```bash
-sysctl net.mptcp.enabled=1
+sysctl -w net.mptcp.enabled=1
 ```
 
 {: .note}


### PR DESCRIPTION
This argument is required with some implementations of sysctl, e.g. the one from Busybox.