### PR TITLE
pm: various small improvements.

### DIFF
--- a/pm.md
+++ b/pm.md
@@ -164,6 +164,10 @@ established*, and each time a new subflow is established. This behaviour might
 change in the future, if someone implements the ticket
 [#334](https://github.com/multipath-tcp/mptcp_net-next/issues/334).
 
+By default, [automated tools](#automatic-configuration) will add
+[`subflow`](#endpoints) endpoints, not [`signal`](#endpoints) ones. This
+behavior can be modified, please check their manual.
+
 #### Creating new subflows
 
 There are two cases that involve the creation of new subflows, if allowed by

--- a/pm.md
+++ b/pm.md
@@ -156,7 +156,8 @@ typically when the first data has been sent.
 #### Announcing new addresses
 
 All endpoints flagged as [`signal`](#endpoints) will be announced via an
-`ADD_ADDR` notification.
+`ADD_ADDR` notification. That is typically what a server would do, to let
+clients connect to other available addresses if needed.
 
 This will be done, one at a time: once the MPTCP connection is *fully
 established*, and each time a new subflow is established. This behaviour might

--- a/pm.md
+++ b/pm.md
@@ -93,7 +93,12 @@ additional address and port. This was also called the `ndiffports` technique.
 When used with the [`allow_join_initial_addr_port`](https://docs.kernel.org/networking/mptcp-sysctl.html)
 sysctl set to 0, this can be useful for servers deployed behind a load balancer.
 
-The IP address is an IPv4 or IPv6 address. The endpoints are netns-aware.
+The IP address is an IPv4 or IPv6 address. The endpoints are netns-aware. The
+current endpoints can be seen using:
+
+```sh
+ip mptcp endpoint
+```
 
 #### Example
 
@@ -123,7 +128,12 @@ ip mptcp limits set [ subflows NR ] [ add_addr_accepted NR ]
   notification from the other peer -- that will result in the creation of
   subflows, typically only for the client side (default is 0).
 
-The limits are per MPTCP connection, and netns-aware.
+The limits are per MPTCP connection, and netns-aware. The current limits can be
+seen using:
+
+```sh
+ip mptcp limits
+```
 
 {: .note}
 It is possible to reach the limits with fewer established subflows than

--- a/pm.md
+++ b/pm.md
@@ -34,15 +34,12 @@ As of Linux v5.19, there are two path managers controlled by the netns-aware
 With the (default) in-kernel Path-Manager, the same rules are applied to all
 connections. Address endpoints and limits can be set to control its behavior.
 
-### Configuration
-
-This configuration can be automated with tools like
+Its configuration can be automated with tools like
 [NetworkManager](https://networkmanager.dev) and
-[`mptcpd`](https://mptcpd.mptcp.dev). Here below, the focus is on the manual
-configuration, using the `ip mptcp` command. Please check the manual for more
-details: [`man ip-mptcp`](https://man7.org/linux/man-pages/man8/ip-mptcp.8.html).
+[`mptcpd`](https://mptcpd.mptcp.dev), or done manually using the `ip mptcp`
+command.
 
-#### Automatic configuration
+### Automatic configuration
 
 {: .info }
 NetworkManager 1.40 or newer automatically configures MPTCP endpoints with
@@ -57,6 +54,11 @@ To change this behavior, with NetworkManager, look for the
 while for `mptcpd`, look at the `/etc/mptcpd/mptcpd.conf` config file, or
 disable the service if it is not needed. Make sure not to have both
 NetworkManager and `mptcpd` conflicting to configure the MPTCP endpoints.
+
+### Manual configuration
+
+This can be done using the `ip mptcp` command. Please check the manual for more
+details: [`man ip-mptcp`](https://man7.org/linux/man-pages/man8/ip-mptcp.8.html).
 
 #### Endpoints
 


### PR DESCRIPTION
Here are some small improvements for the PM page:
- reduce title levels
- how to display endpoints and limits
- add a reminder that `ADD_ADDR` are typically for the server side
- add a reminder that that automated tools create `sublow` endpoints by default, not `signal` ones.