### PR TITLE
pm: note about Busybox's ip command

### DIFF
--- a/pm.md
+++ b/pm.md
@@ -59,6 +59,9 @@ NetworkManager and `mptcpd` conflicting to configure the MPTCP endpoints.
 
 This can be done using the `ip mptcp` command. Please check the manual for more
 details: [`man ip-mptcp`](https://man7.org/linux/man-pages/man8/ip-mptcp.8.html).
+Note that Busybox's `ip` command doesn't support MPTCP yet. You need the "full"
+version from the [IPRoute2](https://wiki.linuxfoundation.org/networking/iproute2)
+project.
 
 #### Endpoints
 


### PR DESCRIPTION
It doesn't support MPTCP yet.

Because it is installed in some embedded environments by default, it sounds good to mention that the "full" version is needed, e.g. ip-full in OpenWRT.