### PR TITLE
faq: ssh: more precisions

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -222,7 +222,8 @@ Maybe this native support will come later on. In the meantime, there are
 workarounds: </summary>
 - On the server side:
   - If systemd 257 or newer is in charge of creating the SSH socket, edit its
-    config with `sudo systemctl edit ssh.socket`, then add these two lines:
+    config with `systemctl edit ssh.socket` to add the following lines, then
+    restart the socket with `systemctl restart ssh.socket`:
     ```
     [Socket]
     SocketProtocol=mptcp

--- a/faq.md
+++ b/faq.md
@@ -245,17 +245,19 @@ workarounds: </summary>
     `mptcpize run`, or set `LD_PRELOAD` to the full path of
     `libmptcpwrap.so.0.0.1`.
 - On the client side:
-  - Prefix the command line with `mptcpize run`, e.g.
+  - Prefix the SSH command line (or `scp`, `rsync`, `git`, etc.) with
+    `mptcpize run`, e.g.
     ```
     mptcpize run ssh example.org
     ```
-  - Set the `ProxyCommand` option to use `mptcpize run`, e.g. by using this line
-    in the `~/.ssh/config` file:
+  - An alternative is to set the `ProxyCommand` option to use `mptcpize run`,
+    e.g. by using this line in the `~/.ssh/config` file:
     ```
     Host (...)
         ProxyCommand mptcpize run ssh -W %h:%p -l %r -p %p %h
     ```
-    This is useful not to require a prefix for all `ssh` commands, or if SSH is
-    used by other tools, e.g. `git`, a file manager like Nautilus, Filezilla,
-    etc.
+    This proxy command is less efficient, because it will force `ssh` to be
+    launched a second time as a proxy. But it is useful not to require a prefix
+    for all `ssh` commands, or if SSH is used by other tools, e.g. `git`, a file
+    manager like Nautilus, Filezilla, etc.
 </details> {: .ctsm}


### PR DESCRIPTION
Two small precisions:
- mention `ssh.socket` restart: Even if that makes sense after the modification, it is better to be explicit.
- proxy is an alternative: Clearly mention that the `ProxyCommand` is an alternative, less efficient than using SSH with MPTCP support directly. Also mention that other commands like scp, rsync, git, etc. can be used with `mptcpize run` as well.