### PR TITLE
faq: add GRO support info

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -210,6 +210,28 @@ is to increase the NIC RX queue. See issue
 [#253](https://github.com/multipath-tcp/mptcp_net-next/issues/253) for more
 details.
 
+## Is GRO supported with MPTCP?
+
+Software Generic Receive Offload (GRO) will merge packets when the MAC headers
+are identical, but only specific TCP and IP headers can differ. In other words,
+if the TCP options of one packet following another one are identical, they can
+be merged.
+
+MPTCP adds TCP options in each packet, but when TCP Segmentation Offload (TSO)
+is used, the same MPTCP options will be duplicated in each packet. When such
+packets are received, and if all the other conditions are met, the receiver-side
+software GRO can re-create the sender's original pre-TSO packet because the TCP
+options of the segmented packets are all identical.
+
+With hardware GRO, in theory, NICs can use the same technique. But some of them,
+like many Intel cards, are more "cautious", and they will not merge TCP packets
+if they contain non-supported TCP options, i.e. anything but TCP timestamps.
+With such NICs, hardware GRO cannot work with MPTCP and a fallback to software
+GRO will be done.
+
+When comparing MPTCP performance with another protocol, it is then interesting
+to check if hardware GRO is used in both cases.
+
 ## How to enable MPTCP support with OpenSSH?
 
 <details markdown="block">


### PR DESCRIPTION
At Netdev 0x19, there were some discussions about hardware GRO: Eric reported that when comparing performances of TCP with MPTCP single-path, a performance drop can be explained by hardware GRO not being used with MPTCP.

Apparently, some NIC's skip hardware GRO in presence of "unknown" TCP options: anything but TCP timestamps. At least that what people who worked on Intel NIC's said. (I hope that's OK to mention Intel here, that's apparently specific to them, but I don't know more about that.)

It then seems interesting to write this down in the FAQ to help people understanding why hardware GRO might not be used with MPTCP. While at it, explain that software GRO works when TSO was used on the sender side.