### PR TITLE
apps: add Caddy and Traefik

### DIFF
--- a/apps.md
+++ b/apps.md
@@ -16,6 +16,7 @@ mentioned. Please note that other apps can be forced to use it by following
 | --- | --- | --- |
 | [Apache HTTP Server](https://httpd.apache.org) | [2.5.1](https://svn.apache.org/viewvc?view=revision&revision=1920586) | [`Listen 80 options=multipathtcp`](https://github.com/apache/httpd/pull/476/commits/0d56d533f4af) or [`ProxyPass multipathtcp=On`](https://github.com/apache/httpd/pull/476/commits/dfa6aec0dc74) |
 | [Apache Traffic Server](https://trafficserver.apache.org/) | [9.2.4](https://github.com/apache/trafficserver/pull/10701) | [`server_ports: <port> mptcp`](https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html) |
+| [Caddy](https://caddyserver.com) | [v2.10.0](https://github.com/caddyserver/caddy/releases/tag/v2.10.0) | Enabled by default since v2.10.0 (Go 1.24), controllable with [`GODEBUG=multipath=`](https://go.dev/doc/godebug) since v2.7.4 (Go 1.21) |
 | [cURL](https://curl.se/) | [8.9.0](https://github.com/curl/curl/pull/13278) | [`--mptcp`](https://curl.se/docs/manpage.html) |
 | [dae](https://github.com/daeuniverse/dae) | [v0.8.0](https://github.com/daeuniverse/dae/pull/601) | [`global { mptcp: true }`](https://github.com/daeuniverse/dae/blob/main/example.dae) |
 | [Envoy](https://www.envoyproxy.io/) | [1.21.0](https://github.com/envoyproxy/envoy/pull/18780) | [`"enable_mptcp": "true"`](https://www.envoyproxy.io/docs/envoy/v1.21.6/api-v3/config/listener/v3/listener.proto#envoy-v3-api-field-config-listener-v3-listener-enable-mptcp) (`listening` config) |

--- a/apps.md
+++ b/apps.md
@@ -30,6 +30,7 @@ mentioned. Please note that other apps can be forced to use it by following
 | [Shadowsocks Go](https://github.com/database64128/shadowsocks-go) | [v1.9.0](https://github.com/database64128/shadowsocks-go/commit/49a094a3722a) | [`servers.tcpListeners.multipath`](https://github.com/database64128/shadowsocks-go/blob/673cc9217ef5/docs/config.json#L33), [`clients.multipathTCP`](https://github.com/database64128/shadowsocks-go/blob/673cc9217ef5/docs/config.json#L297) |
 | [sing-box](https://sing-box.sagernet.org) | [v1.4.0](https://github.com/SagerNet/sing-box/commit/1019ecfdcfb7) | [`"tcp_multi_path": true`](https://sing-box.sagernet.org/configuration/shared/listen/#tcp_multi_path) |
 | [SystemD](https://systemd.io/) | [v257](https://github.com/systemd/systemd/pull/32958) | [`SocketProtocol=mptcp`](https://www.freedesktop.org/software/systemd/man/latest/systemd.socket.html) (`[Socket]` section) |
+| [Traefik](https://traefik.io) | [v2.10.5](https://github.com/traefik/traefik/releases/tag/v2.10.5) | Controllable with [`GODEBUG=multipath=`](https://go.dev/doc/godebug) |
 | [v2ray-core](https://github.com/v2fly/v2ray-core) | [v5.17.0](https://github.com/v2fly/v2ray-core/pull/3109) | [`"mptcp": true`](https://www.v2fly.org/en_US/config/transport.html#sockoptobject) |
 | [Valkey](https://valkey.io) | [v8.2.0](https://github.com/valkey-io/valkey/pull/1811) | [`mptcp yes`](https://github.com/valkey-io/valkey/commit/4a92db917858696120c9ef078b08f8e17c21125b#diff-dd9a6c95849b36490b9bae44e9f0d3dbcd7a93080cf2d5aee6d6033586ab8fa4R158) |
 


### PR DESCRIPTION
Two popular HTTP Go apps. Caddy recently switched to Go 1.24 and has MPTCP support enabled by default.