### PR TITLE
apps: tools: add BCC's mptcpify

### DIFF
--- a/apps.md
+++ b/apps.md
@@ -74,6 +74,7 @@ Do not hesitate to contribute to the packaging, and to update this table!
 
 | Name | Version | Comment |
 | --- | --- | --- |
+| [BCC](https://github.com/iovisor/bcc) | [v0.35.0](https://github.com/iovisor/bcc/pull/5274) | `mptcpify` tool uses eBPF to force apps creating MPTCP sockets instead of TCP ones |
 | [NFTables](https://wiki.nftables.org/wiki-nftables/index.php/Main_Page) | [v1.0.2](https://lore.kernel.org/netdev/YhO5Pn+6+dgAgSd9@salvia/) | Can specify `mptcp` in TCP option, subtype IDs + symbols since [v1.1.2](https://lore.kernel.org/netdev/Z_1KxMUDT0D8e6wH@calendula/) |
 | [pTCPDump](https://github.com/mozillazg/ptcpdump) | [v0.24.0](https://github.com/mozillazg/ptcpdump/pull/152) | Can decode MPTCP options in TCP packets |
 | [Syzkaller](https://github.com/google/syzkaller) | [Feb 2020](https://github.com/google/syzkaller/pull/1579) | Can exercise MPTCP sockets and Netlink APIs |

--- a/setup.md
+++ b/setup.md
@@ -92,7 +92,8 @@ GODEBUG=multipathtcp=1 <command>
 - [eBPF](https://ebpf.io/what-is-ebpf/): since kernel v6.6, it is possible to
   change the socket being created per cGroup. A small eBPF program -- e.g.
   [mptcpify](https://elixir.bootlin.com/linux/latest/source/tools/testing/selftests/bpf/progs/mptcpify.c) --
-  can be used, see [this example](https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=ddba122428a7).
+  can be used, see [this example](https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=ddba122428a7)
+  or [this one](https://github.com/iovisor/bcc/pull/5274).
 
 - [SystemTap](https://sourceware.org/systemtap/) can also be used to modify the
   `socket` system call. See this [documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/getting-started-with-multipath-tcp_configuring-and-managing-networking#preparing-rhel-to-enable-mptcp-support_getting-started-with-multipath-tcp)


### PR DESCRIPTION
A new BCC tool -- mptcpify, using eBPF -- has been recently added by @Dwyane-Yan to easily force apps creating MPTCP sockets instead of TCP ones.

While at it, also mention it in the Setup section, with the other examples related to eBPF.